### PR TITLE
tv11: 100% when there are no tvcon connections.

### DIFF
--- a/11.h
+++ b/11.h
@@ -32,6 +32,7 @@ int readn(int fd, void *data, int n);
 int dial(char *host, int port);
 void serve(int port, void (*handlecon)(int, void*), void *arg);
 void nodelay(int fd);
+void sleep_ms (uint32 ms);
 
 word sgn(word w);
 word sxt(byte b);

--- a/ka11.c
+++ b/ka11.c
@@ -558,18 +558,6 @@ service:
 		return;
 }
 
-static void sleep_ms (uint32 ms)
-{
-	struct timespec ts;
-
-	if (ms == 0)
-		return;
-
-	ts.tv_sec = ms / 1000;
-	ts.tv_nsec = (ms % 1000) * 1000000;
-	(void)nanosleep (&ts, NULL);
-}
-
 void
 run(KA11 *cpu)
 {

--- a/tv.c
+++ b/tv.c
@@ -712,9 +712,10 @@ handletv_thread(void *arg)
 			conmap[nfds] = i;
 			nfds++;
 		}
-		if(nfds == 0)
-			/* TODO: sleep until there's fds */
+		if(nfds == 0){
+			sleep_ms (200);
 			continue;
+		}
 
 		/* We need a timeout here so poll can see
 		 * when we open a new connection */

--- a/tv.c
+++ b/tv.c
@@ -455,7 +455,7 @@ sendfb(TV *tv, int osw)
 	w2b(b+6, HEIGHT);
 	b += 8;
 	packfb(tv, b, con->dpy, 0, 0, WIDTH/16, HEIGHT);
-	write(con->fd, largebuf, 3+8+WIDTH*HEIGHT/8);
+	writen(con->fd, largebuf, 3+8+WIDTH*HEIGHT/8);
 }
 
 void
@@ -499,7 +499,7 @@ sendupdate(TV *tv, FBuffer *buffer, uint16 addr)
 		bw1 = n1 < 0 ? 0 : tv->buffers[n1].mask;
 		bw2 = n2 < 0 ? 0 : tv->buffers[n2].mask;
 		w2b(buf+5, w1^bw1 | w2^bw2);
-		write(tv->cons[tv->omap[osw]].fd, buf, 7);
+		writen(tv->cons[tv->omap[osw]].fd, buf, 7);
 	}
 }
 
@@ -682,7 +682,7 @@ err:
 		w2b(b+6, h);
 		b += 8;
 		packfb(tv, b, con->dpy, x, y, w, h);
-		write(con->fd, largebuf, 3+8+w*h*2);
+		writen(con->fd, largebuf, 3+8+w*h*2);
 		break;
 
 	default:

--- a/util.c
+++ b/util.c
@@ -113,3 +113,16 @@ nodelay(int fd)
 	int flag = 1;
 	setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(flag));
 }
+
+void
+sleep_ms (uint32 ms)
+{
+	struct timespec ts;
+
+	if (ms == 0)
+		return;
+
+	ts.tv_sec = ms / 1000;
+	ts.tv_nsec = (ms % 1000) * 1000000;
+	(void)nanosleep (&ts, NULL);
+}

--- a/util.c
+++ b/util.c
@@ -40,6 +40,22 @@ readn(int fd, void *data, int n)
 }
 
 int
+writen(int fd, void *data, int n)
+{
+	int m;
+
+	while(n > 0){
+		m = write(fd, data, n);
+		if(m <= 0)
+			return -1;
+		data += m;
+		n -= m;
+	}
+
+	return 0;
+}
+
+int
 dial(char *host, int port)
 {
 	char portstr[32];


### PR DESCRIPTION
tv11 consumes 100% CPU if there are no tvcon connections, even if -s is used.  I'm guessing some thread is running full speed waiting to accept a socket?