### PR TITLE
Initialize tvcon fd.

### DIFF
--- a/tv11.c
+++ b/tv11.c
@@ -379,6 +379,7 @@ main(int argc, char *argv[])
 
 	host = argv[0];
 	ten11.cycle = 0;
+	ten11.fd = -1;
 	loadmem("mem.txt");
 
 //	if(loadpt("maindec/MAINDEC-11-D0NA-PB.ptap"))


### PR DESCRIPTION
In a previous change, I forgot to set fd to a negative value.  This means reconnect() is never called, so the socket connection isn't established.