### PR TITLE
Use the SDL thread and net APIs instead of pthread and BSD socket.

### DIFF
--- a/tvcon/Makefile
+++ b/tvcon/Makefile
@@ -1,4 +1,4 @@
 CFLAGS=-O3 `sdl2-config --cflags`
-LDLIBS=`sdl2-config --libs` -lpthread
+LDLIBS=`sdl2-config --libs` -lSDL2_net
 tvcon: tvcon.c
 	cc $(CFLAGS) -o $@ $< $(LDLIBS)


### PR DESCRIPTION
Modify tvcon to use the SDL thread and net APIs instead of pthread and BSD socket.  With this change, tvcon can be built on Windows with only SDL APIs.

The thread API is built into SDL, but SDL_Net is a separate library which needs to be installed.

I'm posting this as a **DRAFT** until tested on Windows.  Meanwhile, reviews or comments are welcome.